### PR TITLE
Remove Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5420,15 +5420,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "axios": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
-      "requires": {
-        "follow-redirects": "^1.2.3",
-        "is-buffer": "^1.1.5"
-      }
-    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -11024,6 +11015,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
       "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+      "dev": true,
       "requires": {
         "debug": "^2.4.5"
       }
@@ -13039,7 +13031,8 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@loadable/component": "^5.9.0",
     "@loadable/server": "^5.9.0",
     "async": "^2.6.2",
-    "axios": "^0.16.2",
     "chalk": "^2.4.2",
     "ejs": "^2.6.1",
     "express": "^4.16.4",


### PR DESCRIPTION
Axios becomes unused and with the high severity security vulnerability detected in Axios <= 0.18.0, it was removed from this repository.